### PR TITLE
ABZU-52515 additional macros

### DIFF
--- a/Tests/UnitTests/FileShareService.DesktopClient.CoreTests/sampleActionsWithDayAndMonthMacros.json
+++ b/Tests/UnitTests/FileShareService.DesktopClient.CoreTests/sampleActionsWithDayAndMonthMacros.json
@@ -1,0 +1,88 @@
+{
+  "jobs": [
+    {
+      "action": "newBatch",
+      "displayName": "Macro test",
+      "actionParams": {
+        "businessUnit": "ADDS",
+        "attributes": [
+          {
+            "key": "$(now.Day)/$(now.AddDays(7).Day)/$(now.AddDays(20).Day)",
+            "value": "$(now.Day)/$(now.AddDays(7).Day)/$(now.AddDays(20).Day)"
+          },
+          {
+            "key": "$(now.Day2)/$(now.AddDays(7).Day2)/$(now.AddDays(20).Day2)",
+            "value": "$(now.Day2)/$(now.AddDays(7).Day2)/$(now.AddDays(20).Day2)"
+          },
+          {
+            "key": "$(now.Month)/$(now.AddDays(28).Month)/$(now.AddDays(-1).Month)",
+            "value": "$(now.Month)/$(now.AddDays(28).Month)/$(now.AddDays(-1).Month)"
+          },
+          {
+            "key": "$(now.Month2)/$(now.AddDays(28).Month2)/$(now.AddDays(-1).Month2)",
+            "value": "$(now.Month2)/$(now.AddDays(28).Month2)/$(now.AddDays(-1).Month2)"
+          }
+        ],
+        "acl": {
+          "readUsers": [],
+          "readGroups": []
+        },
+        "expiryDate": "$(now.AddDays(21))",
+        "files": [
+          {
+            "searchPath": "u:\\\\$(now.Day)\\$(now.AddDays(7).Day)\\$(now.AddDays(20).Day)\\$(now.Day2)\\$(now.AddDays(7).Day2)\\$(now.AddDays(20).Day2)",
+            "expectedFileCount": 1,
+            "mimeType": "application/test"
+          },
+          {
+            "searchPath": "u:\\\\$(now.Month)\\$(now.AddDays(28).Month)\\$(now.AddDays(-1).Month)\\$(now.Month2)\\$(now.AddDays(28).Month2)\\$(now.AddDays(-1).Month2)",
+            "expectedFileCount": 1,
+            "mimeType": "application/test"
+          }
+        ]
+      }
+    },
+    {
+      "action": "newBatch",
+      "displayName": "Macro test 2",
+      "actionParams": {
+        "businessUnit": "ADDS",
+        "attributes": [
+          {
+            "key": "$(now.MonthName)/$(now.MonthShortName)",
+            "value": "$(now.MonthName)/$(now.MonthShortName)"
+          },
+          {
+            "key": "$(now.AddDays(31).MonthName)/$(now.AddDays(31).MonthShortName)",
+            "value": "$(now.AddDays(31).MonthName)/$(now.AddDays(31).MonthShortName)"
+          },
+          {
+            "key": "$(now.DayName)/$(now.DayShortName)",
+            "value": "$(now.DayName)/$(now.DayShortName)"
+          },
+          {
+            "key": "$(now.AddDays(2).DayName)/$(now.AddDays(-2).DayShortName)",
+            "value": "$(now.AddDays(2).DayName)/$(now.AddDays(-2).DayShortName)"
+          }
+        ],
+        "acl": {
+          "readUsers": [],
+          "readGroups": []
+        },
+        "expiryDate": "$(now.AddDays(21))",
+        "files": [
+          {
+            "searchPath": "u:\\\\$(now.MonthName)\\$(now.MonthShortName)\\$(now.AddDays(31).MonthName)\\$(now.AddDays(31).MonthShortName)",
+            "expectedFileCount": 1,
+            "mimeType": "application/test"
+          },
+          {
+            "searchPath": "u:\\\\$(now.DayName)\\$(now.DayShortName)\\$(now.AddDays(2).DayName)\\$(now.AddDays(-2).DayShortName)",
+            "expectedFileCount": 1,
+            "mimeType": "application/test"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Tests/UnitTests/FileShareService.DesktopClientTests/Helper/MacroTransformerTests.cs
+++ b/Tests/UnitTests/FileShareService.DesktopClientTests/Helper/MacroTransformerTests.cs
@@ -85,8 +85,6 @@ namespace FileShareService.DesktopClientTests.Helper
         [TestCase("$(now.AddDays(-1))", "12/30/2022 00:00:00")]
         [TestCase("$(now.AddDays(-14))", "12/17/2022 00:00:00")]
         [TestCase("$(now.AddDays( - 1 ))", "12/30/2022 00:00:00")]
-
-        
         public void DecemberTests(string input, string expected)
         {
             A.CallTo(() => fakeCurrentDateTimeProvider.CurrentDateTime)
@@ -120,7 +118,6 @@ namespace FileShareService.DesktopClientTests.Helper
         [TestCase("$(now.Month2)", "02")]
         [TestCase("$( now.AddDays( 28).Month2 )", "03")]
         [TestCase("$(now.AddDays(-1).Month2)", "01")]
-
         public void FebruaryTests(string input, string expected)
         {
             A.CallTo(() => fakeCurrentDateTimeProvider.CurrentDateTime)
@@ -129,8 +126,53 @@ namespace FileShareService.DesktopClientTests.Helper
             var transformer = new MacroTransformer(fakeCurrentDateTimeProvider);
 
             Assert.AreEqual(expected, transformer.ExpandMacros(input));
-
         }
 
+        [TestCase(1, "$(now.MonthName)", "January")]
+        [TestCase(1, "$(now.MonthShortName)", "Jan")]
+        [TestCase(1, "$( now.AddDays( +31 ).MonthName )", "February")]
+        [TestCase(1, "$( now.AddDays(+31 ).MonthShortName )", "Feb")]
+        [TestCase(3, "$( now.MonthName)", "March")]
+        [TestCase(3, "$(now.MonthShortName )", "Mar")]
+        [TestCase(4, "$(now.MonthName )", "April")]
+        [TestCase(4, "$( now.MonthShortName )", "Apr")]
+        [TestCase(5, "$(now.MonthName )", "May")]
+        [TestCase(5, "$( now.MonthShortName )", "May")]
+        [TestCase(6, "$(now.MonthName )", "June")]
+        [TestCase(6, "$( now.MonthShortName )", "Jun")]
+        [TestCase(7, "$(now.MonthName)", "July")]
+        [TestCase(7, "$(now.MonthShortName)", "Jul")]
+        [TestCase(8, "$(now.MonthName)", "August")]
+        [TestCase(8, "$(now.MonthShortName)", "Aug")]
+        [TestCase(9, "$(now.MonthName)", "September")]
+        [TestCase(9, "$(now.MonthShortName)", "Sep")]
+        [TestCase(10, "$(now.MonthName)", "October")]
+        [TestCase(10, "$(now.MonthShortName)", "Oct")]
+        [TestCase(11, "$(now.MonthName)", "November")]
+        [TestCase(11, "$(now.MonthShortName)", "Nov")]
+        [TestCase(12, "$(now.MonthName)", "December")]
+        [TestCase(12, "$(now.MonthShortName)", "Dec")]
+        public void MonthNameTests(int month, string input, string expected)
+        {
+            A.CallTo(() => fakeCurrentDateTimeProvider.CurrentDateTime)
+                .Returns(new DateTime(2022, month, 01, 0, 0, 0, DateTimeKind.Utc));
+
+            var transformer = new MacroTransformer(fakeCurrentDateTimeProvider);
+
+            Assert.AreEqual(expected, transformer.ExpandMacros(input));
+        }
+
+        [TestCase("$(now.Month) $(now.MonthName)", "1 January")]
+        [TestCase("$(now.MonthName) $(now.Month)", "January 1")]
+        [TestCase("$(now.MonthName) $(now.Month) $(now.MonthName)", "January 1 January")]
+        public void MonthMatching(string input, string expected)
+        {
+            A.CallTo(() => fakeCurrentDateTimeProvider.CurrentDateTime)
+                .Returns(new DateTime(2022, 01, 01, 0, 0, 0, DateTimeKind.Utc));
+
+            var transformer = new MacroTransformer(fakeCurrentDateTimeProvider);
+
+            Assert.AreEqual(expected, transformer.ExpandMacros(input));
+        }
     }
 }

--- a/Tests/UnitTests/FileShareService.DesktopClientTests/Helper/MacroTransformerTests.cs
+++ b/Tests/UnitTests/FileShareService.DesktopClientTests/Helper/MacroTransformerTests.cs
@@ -99,21 +99,27 @@ namespace FileShareService.DesktopClientTests.Helper
         }
 
 
-        [TestCase("$(now)", "02/01/2022 00:00:00")]
+        [TestCase("$( now )", "02/01/2022 00:00:00")]
+        [TestCase("$( now.AddDays( 1 ) )", "02/02/2022 00:00:00")]
+        [TestCase("$( now.AddDays(-1) )", "01/31/2022 00:00:00")]
 
-        [TestCase("$(now.Day", "1")]
+        [TestCase("$(now.Day)", "1")]
         [TestCase("$( now.AddDays(7).Day )", "8")]
-        [TestCase("$( now.AddDays(28).Day )", "1")]
+        [TestCase("$( now.AddDays( 28).Day )", "1")]
+        [TestCase("$(now.AddDays(-22 ).Day)", "9")]
 
-        [TestCase("$(now.Day2", "01")]
-        [TestCase("$(now.AddDays(7).Day2)", "08")]
-        [TestCase("$(now.AddDays(28).Day2)", "01")]
+        [TestCase("$(now.Day2)", "01")]
+        [TestCase("$( now.AddDays(7).Day2 )", "08")]
+        [TestCase("$(now.AddDays( 28 ).Day2)", "01")]
+        [TestCase("$(now.AddDays(-22).Day2)", "09")]
 
-        [TestCase("$(now.Month", "2")]
+        [TestCase("$(now.Month)", "2")]
         [TestCase("$(now.AddDays(28).Month)", "3")]
+        [TestCase("$(now.AddDays(-1).Month)", "1")]
 
-        [TestCase("$(now.Month2", "02")]
-        [TestCase("$(now.AddDays(28).Month2)", "03")]
+        [TestCase("$(now.Month2)", "02")]
+        [TestCase("$( now.AddDays( 28).Month2 )", "03")]
+        [TestCase("$(now.AddDays(-1).Month2)", "01")]
 
         public void FebruaryTests(string input, string expected)
         {

--- a/Tests/UnitTests/FileShareService.DesktopClientTests/Helper/MacroTransformerTests.cs
+++ b/Tests/UnitTests/FileShareService.DesktopClientTests/Helper/MacroTransformerTests.cs
@@ -90,10 +90,8 @@ namespace FileShareService.DesktopClientTests.Helper
             A.CallTo(() => fakeCurrentDateTimeProvider.CurrentDateTime)
                 .Returns(new DateTime(2022, 12, 31, 0, 0, 0, DateTimeKind.Utc));
 
-            var transformer = new MacroTransformer(fakeCurrentDateTimeProvider);
+            RunTest(input, expected);
 
-            Assert.AreEqual(expected, transformer.ExpandMacros(input));
-            
         }
 
 
@@ -123,9 +121,7 @@ namespace FileShareService.DesktopClientTests.Helper
             A.CallTo(() => fakeCurrentDateTimeProvider.CurrentDateTime)
                 .Returns(new DateTime(2022, 02, 01, 0, 0, 0, DateTimeKind.Utc));
 
-            var transformer = new MacroTransformer(fakeCurrentDateTimeProvider);
-
-            Assert.AreEqual(expected, transformer.ExpandMacros(input));
+            RunTest(input, expected);
         }
 
         [TestCase(1, "$(now.MonthName)", "January")]
@@ -157,9 +153,7 @@ namespace FileShareService.DesktopClientTests.Helper
             A.CallTo(() => fakeCurrentDateTimeProvider.CurrentDateTime)
                 .Returns(new DateTime(2022, month, 01, 0, 0, 0, DateTimeKind.Utc));
 
-            var transformer = new MacroTransformer(fakeCurrentDateTimeProvider);
-
-            Assert.AreEqual(expected, transformer.ExpandMacros(input));
+            RunTest(input, expected);
         }
 
         [TestCase("$(now.Month) $(now.MonthName)", "1 January")]
@@ -170,11 +164,8 @@ namespace FileShareService.DesktopClientTests.Helper
             A.CallTo(() => fakeCurrentDateTimeProvider.CurrentDateTime)
                 .Returns(new DateTime(2022, 01, 01, 0, 0, 0, DateTimeKind.Utc));
 
-            var transformer = new MacroTransformer(fakeCurrentDateTimeProvider);
-
-            Assert.AreEqual(expected, transformer.ExpandMacros(input));
+            RunTest(input, expected);
         }
-
 
         [TestCase(4, "$(now.DayName)", "Monday")]
         [TestCase(4, "$(now.DayShortName)", "Mon")]
@@ -195,9 +186,24 @@ namespace FileShareService.DesktopClientTests.Helper
             A.CallTo(() => fakeCurrentDateTimeProvider.CurrentDateTime)
                 .Returns(new DateTime(2022, 07, day, 0, 0, 0, DateTimeKind.Utc));
 
+            RunTest(input, expected);
+        }
+
+        private void RunTest(string input, string expanded)
+        {
             var transformer = new MacroTransformer(fakeCurrentDateTimeProvider);
 
-            Assert.AreEqual(expected, transformer.ExpandMacros(input));
+            Assert.AreEqual(expanded, transformer.ExpandMacros(input));
+
+            var macroBetwix = $"\\\\ukho.business.data\\{input}\\files";
+            var expandedBetwix = $"\\\\ukho.business.data\\{expanded}\\files";
+
+            Assert.AreEqual(expandedBetwix, transformer.ExpandMacros(macroBetwix));
+
+            macroBetwix = $"| {input} |";
+            expandedBetwix = $"| {expanded} |";
+
+            Assert.AreEqual(expandedBetwix, transformer.ExpandMacros(macroBetwix));
         }
     }
 }

--- a/Tests/UnitTests/FileShareService.DesktopClientTests/Helper/MacroTransformerTests.cs
+++ b/Tests/UnitTests/FileShareService.DesktopClientTests/Helper/MacroTransformerTests.cs
@@ -1,0 +1,130 @@
+﻿using FakeItEasy;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UKHO.FileShareService.DesktopClient.Core;
+using UKHO.FileShareService.DesktopClient.Helper;
+
+namespace FileShareService.DesktopClientTests.Helper
+{
+    [TestFixture]
+    public class MacroTransformerTests
+    {
+        private ICurrentDateTimeProvider fakeCurrentDateTimeProvider = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            fakeCurrentDateTimeProvider = A.Fake<ICurrentDateTimeProvider>();
+        }
+
+        [TestCase("$(now.Year)", "2022")]
+        [TestCase("$(now.Year2)", "22")]
+        [TestCase("$(now.Year   )", "2022")]
+        [TestCase("$(now.Year2   )", "22")]
+        [TestCase("$(   now.Year)", "2022")]
+        [TestCase("$(   now.Year2)", "22")]
+        [TestCase("$(   now.Year   )", "2022")]
+        [TestCase("$(   now.Year2   )", "22")]
+        [TestCase("$(   now.AddDays(30).Year   )", "2023")]
+        [TestCase("$(   now.AddDays(30).Year2   )", "23")]
+        
+        [TestCase("$(now.WeekNumber)", "52")]
+        [TestCase("$(now.AddDays(7).WeekNumber)", "1")]
+        [TestCase("$(now.AddDays(21).WeekNumber)", "3")]
+        [TestCase("$(now.AddDays(-14).WeekNumber)", "50")]
+        [TestCase("$(now.WeekNumber   )", "52")]
+        [TestCase("$(   now.WeekNumber)", "52")]
+        [TestCase("$(   now.WeekNumber   )", "52")]
+        [TestCase("$(now.WeekNumber+1)", "1")]
+        [TestCase("$(now.WeekNumber +1)", "1")]
+        [TestCase("$(now.WeekNumber + 1)", "1")]
+        [TestCase("$(now.WeekNumber+ 1)", "1")]
+        [TestCase("$(now.WeekNumber +10)", "10")]
+        [TestCase("$(now.WeekNumber   -1)", "51")]
+        [TestCase("$(now.WeekNumber-1)", "51")]
+        [TestCase("$(now.WeekNumber -  1)", "51")]
+        [TestCase("$(now.WeekNumber   -10)", "42")]
+
+        [TestCase("$(now.WeekNumber2)", "52")]
+        [TestCase("$(now.AddDays(7).WeekNumber2)", "01")]
+        [TestCase("$(now.AddDays(21).WeekNumber2)", "03")]
+        [TestCase("$(now.AddDays(-14).WeekNumber2)", "50")]
+        [TestCase("$(now.WeekNumber2   )", "52")]
+        [TestCase("$(   now.WeekNumber2)", "52")]
+        [TestCase("$(   now.WeekNumber2   )", "52")]
+        [TestCase("$(now.WeekNumber2+1)", "01")]
+        [TestCase("$(now.WeekNumber2 +1)", "01")]
+        [TestCase("$(now.WeekNumber2 + 1)", "01")]
+        [TestCase("$(now.WeekNumber2+ 1)", "01")]
+        [TestCase("$(now.WeekNumber2 +10)", "10")]
+        [TestCase("$(now.WeekNumber2   -1)", "51")]
+        [TestCase("$(now.WeekNumber2-1)", "51")]
+        [TestCase("$(now.WeekNumber2 -  1)", "51")]
+        [TestCase("$(now.WeekNumber2   -10)", "42")]
+
+        [TestCase("$(now.WeekNumber.Year)", "2022")]
+        [TestCase("$(now.WeekNumber.Year2)", "22")]
+        [TestCase("$(now.AddDays(7).WeekNumber.Year)", "1")]
+        [TestCase("$(now.AddDays(7).WeekNumber.Year2)", "1")]
+        [TestCase("$(now.WeekNumber +10.Year)", "2023")]
+        [TestCase("$(now.WeekNumber +10.Year2)", "23")]
+
+        [TestCase("$(now)", "12/31/2022 00:00:00")]
+        [TestCase("$(now.AddDays(0))", "12/31/2022 00:00:00")]
+        [TestCase("$(now.AddDays(1))", "01/01/2023 00:00:00")]
+        [TestCase("$(now.AddDays(+1))", "01/01/2023 00:00:00")]
+        [TestCase("$(now.AddDays( 1 ))", "01/01/2023 00:00:00")]
+        [TestCase("$(now.AddDays( + 1 ))", "01/01/2023 00:00:00")]
+        [TestCase("$(now.AddDays(7))", "01/07/2023 00:00:00")]
+        [TestCase("$(now.AddDays(31))", "01/31/2023 00:00:00")]
+        [TestCase("$(now.AddDays(365))", "12/31/2023 00:00:00")]
+        [TestCase("$(now.AddDays(-1))", "12/30/2022 00:00:00")]
+        [TestCase("$(now.AddDays(-14))", "12/17/2022 00:00:00")]
+        [TestCase("$(now.AddDays( - 1 ))", "12/30/2022 00:00:00")]
+
+        
+        public void DecemberTests(string input, string expected)
+        {
+            A.CallTo(() => fakeCurrentDateTimeProvider.CurrentDateTime)
+                .Returns(new DateTime(2022, 12, 31, 0, 0, 0, DateTimeKind.Utc));
+
+            var transformer = new MacroTransformer(fakeCurrentDateTimeProvider);
+
+            Assert.AreEqual(expected, transformer.ExpandMacros(input));
+            
+        }
+
+
+        [TestCase("$(now)", "02/01/2022 00:00:00")]
+
+        [TestCase("$(now.Day", "1")]
+        [TestCase("$( now.AddDays(7).Day )", "8")]
+        [TestCase("$( now.AddDays(28).Day )", "1")]
+
+        [TestCase("$(now.Day2", "01")]
+        [TestCase("$(now.AddDays(7).Day2)", "08")]
+        [TestCase("$(now.AddDays(28).Day2)", "01")]
+
+        [TestCase("$(now.Month", "2")]
+        [TestCase("$(now.AddDays(28).Month)", "3")]
+
+        [TestCase("$(now.Month2", "02")]
+        [TestCase("$(now.AddDays(28).Month2)", "03")]
+
+        public void FebruaryTests(string input, string expected)
+        {
+            A.CallTo(() => fakeCurrentDateTimeProvider.CurrentDateTime)
+                .Returns(new DateTime(2022, 02, 01, 0, 0, 0, DateTimeKind.Utc));
+
+            var transformer = new MacroTransformer(fakeCurrentDateTimeProvider);
+
+            Assert.AreEqual(expected, transformer.ExpandMacros(input));
+
+        }
+
+    }
+}

--- a/Tests/UnitTests/FileShareService.DesktopClientTests/Helper/MacroTransformerTests.cs
+++ b/Tests/UnitTests/FileShareService.DesktopClientTests/Helper/MacroTransformerTests.cs
@@ -174,5 +174,30 @@ namespace FileShareService.DesktopClientTests.Helper
 
             Assert.AreEqual(expected, transformer.ExpandMacros(input));
         }
+
+
+        [TestCase(4, "$(now.DayName)", "Monday")]
+        [TestCase(4, "$(now.DayShortName)", "Mon")]
+        [TestCase(4, "$( now.AddDays( +1).DayName )", "Tuesday")]
+        [TestCase(4, "$( now.AddDays(+1 ).DayShortName )", "Tue")]
+        [TestCase(4, "$( now.AddDays( 2 ).DayName)", "Wednesday")]
+        [TestCase(7, "$(now.AddDays( -1 ).DayShortName )", "Wed")]
+        [TestCase(7, "$(now.DayName)", "Thursday")]
+        [TestCase(7, "$( now.DayShortName )", "Thu")]
+        [TestCase(8, "$(now.DayName )", "Friday")]
+        [TestCase(8, "$( now.DayShortName )", "Fri")]
+        [TestCase(9, "$(now.DayName )", "Saturday")]
+        [TestCase(9, "$( now.DayShortName )", "Sat")]
+        [TestCase(10, "$(now.DayName )", "Sunday")]
+        [TestCase(10, "$( now.DayShortName )", "Sun")]
+        public void DayNameTests(int day, string input, string expected)
+        {
+            A.CallTo(() => fakeCurrentDateTimeProvider.CurrentDateTime)
+                .Returns(new DateTime(2022, 07, day, 0, 0, 0, DateTimeKind.Utc));
+
+            var transformer = new MacroTransformer(fakeCurrentDateTimeProvider);
+
+            Assert.AreEqual(expected, transformer.ExpandMacros(input));
+        }
     }
 }

--- a/Tests/UnitTests/FileShareService.DesktopClientTests/Helper/MacroTransformerTests.cs
+++ b/Tests/UnitTests/FileShareService.DesktopClientTests/Helper/MacroTransformerTests.cs
@@ -68,8 +68,8 @@ namespace FileShareService.DesktopClientTests.Helper
 
         [TestCase("$(now.WeekNumber.Year)", "2022")]
         [TestCase("$(now.WeekNumber.Year2)", "22")]
-        [TestCase("$(now.AddDays(7).WeekNumber.Year)", "1")]
-        [TestCase("$(now.AddDays(7).WeekNumber.Year2)", "1")]
+        [TestCase("$(now.AddDays(7).WeekNumber.Year)", "2023")]
+        [TestCase("$(now.AddDays(7).WeekNumber.Year2)", "23")]
         [TestCase("$(now.WeekNumber +10.Year)", "2023")]
         [TestCase("$(now.WeekNumber +10.Year2)", "23")]
 
@@ -104,12 +104,12 @@ namespace FileShareService.DesktopClientTests.Helper
         [TestCase("$(now.Day)", "1")]
         [TestCase("$( now.AddDays(7).Day )", "8")]
         [TestCase("$( now.AddDays( 28).Day )", "1")]
-        [TestCase("$(now.AddDays(-22 ).Day)", "9")]
+        [TestCase("$(now.AddDays(-23 ).Day)", "9")]
 
         [TestCase("$(now.Day2)", "01")]
         [TestCase("$( now.AddDays(7).Day2 )", "08")]
         [TestCase("$(now.AddDays( 28 ).Day2)", "01")]
-        [TestCase("$(now.AddDays(-22).Day2)", "09")]
+        [TestCase("$(now.AddDays(-23).Day2)", "09")]
 
         [TestCase("$(now.Month)", "2")]
         [TestCase("$(now.AddDays(28).Month)", "3")]

--- a/file-share-service-desktop-client/Helper/MacroTransformer.cs
+++ b/file-share-service-desktop-client/Helper/MacroTransformer.cs
@@ -19,64 +19,83 @@ namespace UKHO.FileShareService.DesktopClient.Helper
 
         public string ExpandMacros(string value)
         {
-            Func<Match, string> now_Year = (match) =>
-            {
-                return currentDateTimeProvider.CurrentDateTime.Year.ToString();
-            };
-            Func<Match, string> nowAddDays_Year = (match) =>
+            int offsetCapture(Match match)
             {
                 var capturedNumber = match.Groups[1].Value;
-                var dayOffset = int.Parse(capturedNumber.Replace(" ", ""));
+                return int.Parse(capturedNumber.Replace(" ", ""));
+            } 
+
+            string now_Year(Match match) 
+                => currentDateTimeProvider.CurrentDateTime.Year.ToString();
+
+            string nowAddDays_Year(Match match)
+            {
+                var dayOffset = offsetCapture(match);
                 return currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset).Year.ToString();
             };
-            Func<Match, string> now_WeekNumber = (match) =>
+
+            string now_WeekNumber(Match match) 
+                => WeekNumber.GetUKHOWeekFromDateTime(currentDateTimeProvider.CurrentDateTime).Week.ToString();
+
+            string now_WeekNumberYear(Match match)
+                => WeekNumber.GetUKHOWeekFromDateTime(currentDateTimeProvider.CurrentDateTime).Year.ToString();
+
+            string now_WeekNumberPlusWeeks(Match match)
             {
-                return WeekNumber.GetUKHOWeekFromDateTime(currentDateTimeProvider.CurrentDateTime).Week.ToString();
-            };
-            Func<Match, string> now_WeekNumberYear = (match) =>
-            {
-                return WeekNumber.GetUKHOWeekFromDateTime(currentDateTimeProvider.CurrentDateTime).Year.ToString();
-            };
-            Func<Match, string> now_WeekNumberPlusWeeks = (match) =>
-            {
-                var capturedNumber = match.Groups[1].Value;
-                var dayOffset = int.Parse(capturedNumber.Replace(" ", ""));
+                var dayOffset = offsetCapture(match);
                 return WeekNumber.GetUKHOWeekFromDateTime(currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset * 7)).Week.ToString();
-            };
-            Func<Match, string> now_WeekNumberPlusWeeksYear = (match) =>
+            }
+
+            string now_WeekNumberPlusWeeksYear(Match match)
             {
-                var capturedNumber = match.Groups[1].Value;
-                var dayOffset = int.Parse(capturedNumber.Replace(" ", ""));
+                var dayOffset = offsetCapture(match);
                 return WeekNumber.GetUKHOWeekFromDateTime(currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset * 7)).Year.ToString();
             };
-            Func<Match, string> nowAddDays_Week = (match) =>
+
+            string nowAddDays_WeekNumber(Match match)
             {
-                var capturedNumber = match.Groups[1].Value;
-                var dayOffset = int.Parse(capturedNumber.Replace(" ", ""));
+                var dayOffset = offsetCapture(match);
                 return WeekNumber.GetUKHOWeekFromDateTime(currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset)).Week.ToString();
             };
-            Func<Match, string> nowAddDays_WeekYear = (match) =>
+
+            string nowAddDays_WeekYear(Match match)
             {
-                var capturedNumber = match.Groups[1].Value;
-                var dayOffset = int.Parse(capturedNumber.Replace(" ", ""));
+                var dayOffset = offsetCapture(match);
                 return WeekNumber.GetUKHOWeekFromDateTime(currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset)).Year.ToString();
             };
-            Func<Match, string> nowAddDays_Date = (match) =>
+
+            string nowAddDays_Date(Match match)
             {
-                var capturedNumber = match.Groups[1].Value;
-                var dayOffset = int.Parse(capturedNumber.Replace(" ", ""));
-                return currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset)
-                    .ToString(CultureInfo.InvariantCulture);
-            };
-            Func<Match, string> now_Date = (match) =>
-            {
-                return currentDateTimeProvider.CurrentDateTime.ToString(CultureInfo.InvariantCulture);
+                var dayOffset = offsetCapture(match);
+                return currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset).ToString(CultureInfo.InvariantCulture);
             };
 
+            string now_Date(Match match) 
+                => currentDateTimeProvider.CurrentDateTime.ToString(CultureInfo.InvariantCulture);
+
+            string now_Day(Match match)
+                => currentDateTimeProvider.CurrentDateTime.Day.ToString();
+
+
+            string nowAddDays_Day(Match match)
+            {
+                var dayOffset = offsetCapture(match);
+                return currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset).Day.ToString();
+            };
+
+            string now_Month(Match match)
+                => currentDateTimeProvider.CurrentDateTime.Month.ToString();
+
+
+            string nowAddDays_Month(Match match)
+            {
+                var dayOffset = offsetCapture(match);
+                return currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset).Month.ToString();
+            };
 
             var replacementExpressions = new Dictionary<string, Func<Match, string>>
             {
-                {@"\$\(\s*now\.Year\s*\)", now_Year },
+                {@"\$\(\s*now\.Year\s*\)", now_Year},
                 {@"\$\(\s*now\.Year2\s*\)", (match) => now_Year(match).Substring(2,2) },
                 {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Year\s*\)", nowAddDays_Year},
                 {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Year2\s*\)", (match) => nowAddDays_Year(match).Substring(2,2)},
@@ -88,12 +107,20 @@ namespace UKHO.FileShareService.DesktopClient.Helper
                 {@"\$\(\s*now\.WeekNumber2\s*([+-]\s*\d+)\)",(match) => now_WeekNumberPlusWeeks(match).PadLeft(2,'0')},
                 {@"\$\(\s*now\.WeekNumber\s*([+-]\s*\d+)\.Year\)", now_WeekNumberPlusWeeksYear},
                 {@"\$\(\s*now\.WeekNumber\s*([+-]\s*\d+)\.Year2\)", (match) => now_WeekNumberPlusWeeksYear(match).Substring(2,2) },
-                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).WeekNumber\s*\)",nowAddDays_Week },
-                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).WeekNumber2\s*\)",(match) => nowAddDays_Week(match).PadLeft(2,'0')},
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).WeekNumber\s*\)",nowAddDays_WeekNumber },
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).WeekNumber2\s*\)",(match) => nowAddDays_WeekNumber(match).PadLeft(2,'0')},
                 {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).WeekNumber\.Year\s*\)", nowAddDays_WeekYear },
                 {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).WeekNumber\.Year2\s*\)", (match) => nowAddDays_WeekYear(match).Substring(2,2)},
-                {@"\$\(now.AddDays\(\s*([+-]?\s*\d+)\s*\)\)", nowAddDays_Date },
-                {@"\$\(now\)", now_Date}
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\)\s*\)", nowAddDays_Date },
+                {@"\$\(\s*now\s*\)", now_Date},
+                {@"\$\(\s*now\.Day\s*\)", now_Day },
+                {@"\$\(\s*now\.Day2\s*\)", (match) => now_Day(match).PadLeft(2, '0') },
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Day\s*\)", nowAddDays_Day},
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Day2\s*\)", (match) => nowAddDays_Day(match).PadLeft(2, '0')},
+                {@"\$\(\s*now\.Month\s*\)", now_Month },
+                {@"\$\(\s*now\.Month2\s*\)", (match) => now_Month(match).PadLeft(2, '0') },
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Month\s*\)", nowAddDays_Month},
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Month2\s*\)", (match) => nowAddDays_Month(match).PadLeft(2, '0')},
             };
 
             if (string.IsNullOrEmpty(value))

--- a/file-share-service-desktop-client/Helper/MacroTransformer.cs
+++ b/file-share-service-desktop-client/Helper/MacroTransformer.cs
@@ -86,11 +86,28 @@ namespace UKHO.FileShareService.DesktopClient.Helper
             string now_Month(Match match)
                 => currentDateTimeProvider.CurrentDateTime.Month.ToString();
 
-
             string nowAddDays_Month(Match match)
             {
                 var dayOffset = offsetCapture(match);
                 return currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset).Month.ToString();
+            };
+
+            string now_MonthName(Match match)
+                => currentDateTimeProvider.CurrentDateTime.ToString("MMMM");
+
+            string nowAddDays_MonthName(Match match)
+            {
+                var dayOffset = offsetCapture(match);
+                return currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset).ToString("MMMM");
+            };
+
+            string now_MonthShortName(Match match)
+                => currentDateTimeProvider.CurrentDateTime.ToString("MMM");
+
+            string nowAddDays_MonthShortName(Match match)
+            {
+                var dayOffset = offsetCapture(match);
+                return currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset).ToString("MMM");
             };
 
             var replacementExpressions = new Dictionary<string, Func<Match, string>>
@@ -99,6 +116,23 @@ namespace UKHO.FileShareService.DesktopClient.Helper
                 {@"\$\(\s*now\.Year2\s*\)", (match) => now_Year(match).Substring(2,2) },
                 {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Year\s*\)", nowAddDays_Year},
                 {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Year2\s*\)", (match) => nowAddDays_Year(match).Substring(2,2)},
+
+                {@"\$\(\s*now\.Month\s*\)", now_Month },
+                {@"\$\(\s*now\.Month2\s*\)", (match) => now_Month(match).PadLeft(2, '0') },
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Month\s*\)", nowAddDays_Month},
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Month2\s*\)", (match) => nowAddDays_Month(match).PadLeft(2, '0')},
+
+                {@"\$\(\s*now\.Day\s*\)", now_Day },
+                {@"\$\(\s*now\.Day2\s*\)", (match) => now_Day(match).PadLeft(2, '0') },
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Day\s*\)", nowAddDays_Day},
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Day2\s*\)", (match) => nowAddDays_Day(match).PadLeft(2, '0')},
+
+                {@"\$\(\s*now\.MonthName\s*\)", now_MonthName },
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).MonthName\s*\)", nowAddDays_MonthName},
+
+                {@"\$\(\s*now\.MonthShortName\s*\)", now_MonthShortName },
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).MonthShortName\s*\)", nowAddDays_MonthShortName},
+
                 {@"\$\(\s*now\.WeekNumber\s*\)",now_WeekNumber },
                 {@"\$\(\s*now\.WeekNumber2\s*\)",(match) => now_WeekNumber(match).PadLeft(2,'0')},
                 {@"\$\(\s*now\.WeekNumber\.Year\s*\)", now_WeekNumberYear },
@@ -111,16 +145,9 @@ namespace UKHO.FileShareService.DesktopClient.Helper
                 {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).WeekNumber2\s*\)",(match) => nowAddDays_WeekNumber(match).PadLeft(2,'0')},
                 {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).WeekNumber\.Year\s*\)", nowAddDays_WeekYear },
                 {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).WeekNumber\.Year2\s*\)", (match) => nowAddDays_WeekYear(match).Substring(2,2)},
+
                 {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\)\s*\)", nowAddDays_Date },
                 {@"\$\(\s*now\s*\)", now_Date},
-                {@"\$\(\s*now\.Day\s*\)", now_Day },
-                {@"\$\(\s*now\.Day2\s*\)", (match) => now_Day(match).PadLeft(2, '0') },
-                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Day\s*\)", nowAddDays_Day},
-                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Day2\s*\)", (match) => nowAddDays_Day(match).PadLeft(2, '0')},
-                {@"\$\(\s*now\.Month\s*\)", now_Month },
-                {@"\$\(\s*now\.Month2\s*\)", (match) => now_Month(match).PadLeft(2, '0') },
-                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Month\s*\)", nowAddDays_Month},
-                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).Month2\s*\)", (match) => nowAddDays_Month(match).PadLeft(2, '0')},
             };
 
             if (string.IsNullOrEmpty(value))

--- a/file-share-service-desktop-client/Helper/MacroTransformer.cs
+++ b/file-share-service-desktop-client/Helper/MacroTransformer.cs
@@ -76,7 +76,6 @@ namespace UKHO.FileShareService.DesktopClient.Helper
             string now_Day(Match match)
                 => currentDateTimeProvider.CurrentDateTime.Day.ToString();
 
-
             string nowAddDays_Day(Match match)
             {
                 var dayOffset = offsetCapture(match);
@@ -110,6 +109,24 @@ namespace UKHO.FileShareService.DesktopClient.Helper
                 return currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset).ToString("MMM");
             };
 
+            string now_DayName(Match match)
+                => currentDateTimeProvider.CurrentDateTime.ToString("dddd");
+
+            string nowAddDays_DayName(Match match)
+            {
+                var dayOffset = offsetCapture(match);
+                return currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset).ToString("dddd");
+            };
+
+            string now_DayShortName(Match match)
+                => currentDateTimeProvider.CurrentDateTime.ToString("ddd");
+
+            string nowAddDays_DayShortName(Match match)
+            {
+                var dayOffset = offsetCapture(match);
+                return currentDateTimeProvider.CurrentDateTime.AddDays(dayOffset).ToString("ddd");
+            };
+
             var replacementExpressions = new Dictionary<string, Func<Match, string>>
             {
                 {@"\$\(\s*now\.Year\s*\)", now_Year},
@@ -133,6 +150,12 @@ namespace UKHO.FileShareService.DesktopClient.Helper
                 {@"\$\(\s*now\.MonthShortName\s*\)", now_MonthShortName },
                 {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).MonthShortName\s*\)", nowAddDays_MonthShortName},
 
+                {@"\$\(\s*now\.DayName\s*\)", now_DayName },
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).DayName\s*\)", nowAddDays_DayName},
+
+                {@"\$\(\s*now\.DayShortName\s*\)", now_DayShortName },
+                {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).DayShortName\s*\)", nowAddDays_DayShortName},
+
                 {@"\$\(\s*now\.WeekNumber\s*\)",now_WeekNumber },
                 {@"\$\(\s*now\.WeekNumber2\s*\)",(match) => now_WeekNumber(match).PadLeft(2,'0')},
                 {@"\$\(\s*now\.WeekNumber\.Year\s*\)", now_WeekNumberYear },
@@ -141,6 +164,7 @@ namespace UKHO.FileShareService.DesktopClient.Helper
                 {@"\$\(\s*now\.WeekNumber2\s*([+-]\s*\d+)\)",(match) => now_WeekNumberPlusWeeks(match).PadLeft(2,'0')},
                 {@"\$\(\s*now\.WeekNumber\s*([+-]\s*\d+)\.Year\)", now_WeekNumberPlusWeeksYear},
                 {@"\$\(\s*now\.WeekNumber\s*([+-]\s*\d+)\.Year2\)", (match) => now_WeekNumberPlusWeeksYear(match).Substring(2,2) },
+
                 {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).WeekNumber\s*\)",nowAddDays_WeekNumber },
                 {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).WeekNumber2\s*\)",(match) => nowAddDays_WeekNumber(match).PadLeft(2,'0')},
                 {@"\$\(\s*now.AddDays\(\s*([+-]?\s*\d+)\s*\).WeekNumber\.Year\s*\)", nowAddDays_WeekYear },


### PR DESCRIPTION
Hi Kyle,

 

I’ve got a couple more requests around the FSS Tooling Client. They both relate to “macros” that dynamically calculate values when the config file is uploaded and would save a user manually editing the config file every time they need to use it. This is particularly useful for a user who uploads at least daily and on a regular schedule. For example, Andy Cavill who is not at all technical and currently having to get to grips with multiple config files.

 

Currently, we can use the following macro to define a 4 digit value for “year” (there’s also a 2 digit version):

 

$(now.AddDays(10).WeekNumber.Year)

 

We can also currently use the following macro to define a 2 digit value for the “week” number that changes on Thursdays:

 

$(now.AddDays(10).WeekNumber2)

 

What we’d like the FSS Tooling client to be able to do is the same thing for a 1 and 2 digit “day”. E.g. “06” or “6” for the 6th of August.

Similarly, a 1 and 2 digit “month”. E.g. “08” and “8” for August.

 

I don’t currently have a use for a macro that would enable “Mon”, “Monday”, “Aug”, “August” but if it’s easy enough to add those on too, I think that would be helpful.

Brent Pyle
Technical Product Manager

