### PR TITLE
Feature/abzu 211600 dot net 8 upgrade

### DIFF
--- a/FileShareService.DesktopClient.Core/FileShareService.DesktopClient.Core.csproj
+++ b/FileShareService.DesktopClient.Core/FileShareService.DesktopClient.Core.csproj
@@ -1,4 +1,4 @@
-﻿﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>

--- a/FileShareService.DesktopClient.Core/FileShareService.DesktopClient.Core.csproj
+++ b/FileShareService.DesktopClient.Core/FileShareService.DesktopClient.Core.csproj
@@ -1,21 +1,23 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>UKHO.FileShareService.DesktopClient.Core</RootNamespace>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="JsonSubTypes" Version="2.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.55.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.84.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="Prism.Core" Version="8.1.97" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.32.1" />
-		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.1" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
 		<PackageReference Include="UKHO.FileShareAdminClient" Version="1.6.30104.1" />
 		<PackageReference Include="UKHO.FileShareClient" Version="1.6.30104.1" />
+		<PackageReference Include="System.Text.Json" Version="10.0.7" />
+		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 	</ItemGroup>
 
 </Project>

--- a/Tests/UnitTests/FileShareService.DesktopClient.CoreTests/FileShareService.DesktopClient.CoreTests.csproj
+++ b/Tests/UnitTests/FileShareService.DesktopClient.CoreTests/FileShareService.DesktopClient.CoreTests.csproj
@@ -1,4 +1,4 @@
-﻿﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net8.0-windows</TargetFramework>

--- a/Tests/UnitTests/FileShareService.DesktopClient.CoreTests/FileShareService.DesktopClient.CoreTests.csproj
+++ b/Tests/UnitTests/FileShareService.DesktopClient.CoreTests/FileShareService.DesktopClient.CoreTests.csproj
@@ -1,49 +1,48 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>net8.0-windows</TargetFramework>
 
-    <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="sampleActions.json" />
-    <None Remove="sampleActionsWithDuplicateJobs.json" />
-    <None Remove="sampleActionsWithFileAttributes.json" />
-    <None Remove="sampleActionsWithInvalidFormat.json" />
-    <None Remove="sampleActionsWithUnspecifiedFileCount.json" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="sampleActions.json" />
+		<None Remove="sampleActionsWithDuplicateJobs.json" />
+		<None Remove="sampleActionsWithFileAttributes.json" />
+		<None Remove="sampleActionsWithInvalidFormat.json" />
+		<None Remove="sampleActionsWithUnspecifiedFileCount.json" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="sampleActionsWithUnspecifiedFileCount.json" />
-    <EmbeddedResource Include="sampleActionsWithFileAttributes.json" />
-    <EmbeddedResource Include="sampleActions.json" />
-    <EmbeddedResource Include="sampleActionsWithInvalidFormat.json" />
-    <EmbeddedResource Include="sampleActionsWithDuplicateJobs.json" />
-  </ItemGroup>
+	<ItemGroup>
+		<EmbeddedResource Include="sampleActionsWithUnspecifiedFileCount.json" />
+		<EmbeddedResource Include="sampleActionsWithFileAttributes.json" />
+		<EmbeddedResource Include="sampleActions.json" />
+		<EmbeddedResource Include="sampleActionsWithInvalidFormat.json" />
+		<EmbeddedResource Include="sampleActionsWithDuplicateJobs.json" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="7.4.0" />
-    <PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="6.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="FakeItEasy" Version="7.4.0" />
+		<PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="6.1.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="NUnit" Version="3.13.3" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\FileShareService.DesktopClient.Core\FileShareService.DesktopClient.Core.csproj" />
-    <ProjectReference Include="..\FileShareService.DesktopClientTests\FileShareService.DesktopClientTests.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\FileShareService.DesktopClient.Core\FileShareService.DesktopClient.Core.csproj" />
+		<ProjectReference Include="..\FileShareService.DesktopClientTests\FileShareService.DesktopClientTests.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="environments.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="environments.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/Tests/UnitTests/FileShareService.DesktopClientTests/FileShareService.DesktopClientTests.csproj
+++ b/Tests/UnitTests/FileShareService.DesktopClientTests/FileShareService.DesktopClientTests.csproj
@@ -1,27 +1,27 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>net8.0-windows</TargetFramework>
 
-    <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="7.4.0" />
-    <PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="6.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.10" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.31" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="FakeItEasy" Version="7.4.0" />
+		<PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="6.1.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.26" />
+		<PackageReference Include="NUnit" Version="3.13.3" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+		<PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.31" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\file-share-service-desktop-client\FileShareService.DesktopClient.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\file-share-service-desktop-client\FileShareService.DesktopClient.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Tests/UnitTests/FileShareService.DesktopClientTests/FileShareService.DesktopClientTests.csproj
+++ b/Tests/UnitTests/FileShareService.DesktopClientTests/FileShareService.DesktopClientTests.csproj
@@ -1,4 +1,4 @@
-﻿﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net8.0-windows</TargetFramework>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,6 +41,8 @@ variables:
     value: NautilusBuild
   - name: snykAbzuOrganizationId
     value: aeb7543b-8394-457c-8334-a31493d8910d
+  - name: SdkVersion
+    value: "8.x"
 
 stages:
   - stage: VulnerabilityChecks
@@ -55,7 +57,7 @@ stages:
             displayName: 'Use .NET Core sdk'
             inputs:
               packageType: sdk
-              useGlobalJson: true
+              version: $(SdkVersion)
 
           - task: DotNetCoreCLI@2
             displayName: .NET - NuGet restore
@@ -122,7 +124,7 @@ stages:
             displayName: 'Use .NET Core sdk'
             inputs:
               packageType: sdk
-              useGlobalJson: true
+              version: $(SdkVersion)
 
           - task: NuGetToolInstaller@1
             inputs:
@@ -198,7 +200,7 @@ stages:
             displayName: 'Use .NET Core sdk'
             inputs:
               packageType: sdk
-              useGlobalJson: true
+              version: $(SdkVersion)
 
           - task: DotNetCoreCLI@2
             displayName: Publish Project

--- a/file-share-service-desktop-client/FileShareService.DesktopClient.csproj
+++ b/file-share-service-desktop-client/FileShareService.DesktopClient.csproj
@@ -1,4 +1,4 @@
-﻿﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>

--- a/file-share-service-desktop-client/FileShareService.DesktopClient.csproj
+++ b/file-share-service-desktop-client/FileShareService.DesktopClient.csproj
@@ -1,66 +1,66 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <RootNamespace>UKHO.FileShareService.DesktopClient</RootNamespace>
-	<PublishSingleFile>true</PublishSingleFile>
-    <UseWPF>true</UseWPF>
-    <Nullable>enable</Nullable>
-    <ApplicationIcon>favicon.ico</ApplicationIcon>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-	<SelfContained>true</SelfContained>
-	<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<TargetFramework>net8.0-windows</TargetFramework>
+		<RootNamespace>UKHO.FileShareService.DesktopClient</RootNamespace>
+		<PublishSingleFile>true</PublishSingleFile>
+		<UseWPF>true</UseWPF>
+		<Nullable>enable</Nullable>
+		<ApplicationIcon>favicon.ico</ApplicationIcon>
+		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
+		<SelfContained>true</SelfContained>
+		<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="Fonts\JOHNSTONITCSTD_BOLD.OTF" />
-    <None Remove="Fonts\JOHNSTONITCSTD_BOLDITA.OTF" />
-    <None Remove="Fonts\JOHNSTONITCSTD_LIGHT.OTF" />
-    <None Remove="Fonts\JOHNSTONITCSTD_LIGHTITA.OTF" />
-    <None Remove="Fonts\JOHNSTONITCSTD_MEDIUM.OTF" />
-    <None Remove="Fonts\JOHNSTONITCSTD_MEDIUMITA.OTF" />
-    <None Remove="Modules\Auth\image\resources\UKHO-1400x240.jpg" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="Fonts\JOHNSTONITCSTD_BOLD.OTF" />
+		<None Remove="Fonts\JOHNSTONITCSTD_BOLDITA.OTF" />
+		<None Remove="Fonts\JOHNSTONITCSTD_LIGHT.OTF" />
+		<None Remove="Fonts\JOHNSTONITCSTD_LIGHTITA.OTF" />
+		<None Remove="Fonts\JOHNSTONITCSTD_MEDIUM.OTF" />
+		<None Remove="Fonts\JOHNSTONITCSTD_MEDIUMITA.OTF" />
+		<None Remove="Modules\Auth\image\resources\UKHO-1400x240.jpg" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MahApps.Metro" Version="2.4.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+	<ItemGroup>
+		<PackageReference Include="MahApps.Metro" Version="2.4.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.10" />
-    <PackageReference Include="Prism.Unity" Version="8.1.97" />
-    <PackageReference Include="Prism.Wpf" Version="8.1.97" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="13.2.31" />
-    <PackageReference Include="UKHO.WeekNumberUtils" Version="1.5.22270.11" />
-    <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="5.11.5" />
-  </ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.26" />
+		<PackageReference Include="Prism.Unity" Version="8.1.97" />
+		<PackageReference Include="Prism.Wpf" Version="8.1.97" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="7.0.1" />
+		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+		<PackageReference Include="System.IO.Abstractions" Version="13.2.31" />
+		<PackageReference Include="UKHO.WeekNumberUtils" Version="1.5.22270.11" />
+		<PackageReference Include="Unity.Microsoft.DependencyInjection" Version="5.11.5" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\FileShareService.DesktopClient.Core\FileShareService.DesktopClient.Core.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\FileShareService.DesktopClient.Core\FileShareService.DesktopClient.Core.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Resource Include="Fonts\JOHNSTONITCSTD_BOLD.OTF" />
-    <Resource Include="Fonts\JOHNSTONITCSTD_BOLDITA.OTF" />
-    <Resource Include="Fonts\JOHNSTONITCSTD_LIGHT.OTF" />
-    <Resource Include="Fonts\JOHNSTONITCSTD_LIGHTITA.OTF" />
-    <Resource Include="Fonts\JOHNSTONITCSTD_MEDIUM.OTF" />
-    <Resource Include="Fonts\JOHNSTONITCSTD_MEDIUMITA.OTF" />
-    <Resource Include="Modules\Auth\image\resources\UKHO-1400x240.jpg">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </Resource>
-  </ItemGroup>
+	<ItemGroup>
+		<Resource Include="Fonts\JOHNSTONITCSTD_BOLD.OTF" />
+		<Resource Include="Fonts\JOHNSTONITCSTD_BOLDITA.OTF" />
+		<Resource Include="Fonts\JOHNSTONITCSTD_LIGHT.OTF" />
+		<Resource Include="Fonts\JOHNSTONITCSTD_LIGHTITA.OTF" />
+		<Resource Include="Fonts\JOHNSTONITCSTD_MEDIUM.OTF" />
+		<Resource Include="Fonts\JOHNSTONITCSTD_MEDIUMITA.OTF" />
+		<Resource Include="Modules\Auth\image\resources\UKHO-1400x240.jpg">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</Resource>
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="environments.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="appsettings.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="environments.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "6.0.407",
-    "rollForward": "latestFeature"
-  }
-}


### PR DESCRIPTION
This pull request upgrades the solution from .NET 6 to .NET 8, updates related NuGet package dependencies across the main projects and test projects, and modifies the CI pipeline to use the new SDK version. The `global.json` file specifying .NET 6 is removed, and all affected projects and the build pipeline are updated for compatibility with .NET 8.

**.NET 8 Migration and Compatibility Updates:**

* All main and test projects (`FileShareService.DesktopClient.Core`, `FileShareService.DesktopClient`, and test csproj files) are updated to target `.NET 8` instead of `.NET 6`. [[1]](diffhunk://#diff-7de51b2d20ef1d3208370d73cd8cc64b297c4e538cae1e0be269d94eba7c97d0L4-R20) [[2]](diffhunk://#diff-d4ddb9f4f64ecf09bfc543278e461d78140a023db43ece0decc41229fed6d9e2L5-R5) [[3]](diffhunk://#diff-8cc20602e429bbbcc85201dcfd90c61c313f37dc903bd8e2abcf3080337059f9L4-R4) [[4]](diffhunk://#diff-0dec717b0e3ae68dc987282d3743000959980f0938ee07042cc84ce45206bfadL4-R4)
* The `global.json` file, which previously pinned the .NET SDK to version 6.0.407, is removed to allow the use of newer SDKs.

**NuGet Package Updates:**

* Multiple NuGet packages are upgraded to their latest compatible versions for .NET 8, including `Microsoft.Extensions.Logging`, `Microsoft.Identity.Client`, `Newtonsoft.Json`, `System.IdentityModel.Tokens.Jwt`, `System.Security.Cryptography.ProtectedData`, `Microsoft.Extensions.Configuration.Json`, and `Microsoft.Extensions.Http.Polly`. New dependencies such as `System.Text.Json` and `System.Text.RegularExpressions` are added where needed. [[1]](diffhunk://#diff-7de51b2d20ef1d3208370d73cd8cc64b297c4e538cae1e0be269d94eba7c97d0L4-R20) [[2]](diffhunk://#diff-d4ddb9f4f64ecf09bfc543278e461d78140a023db43ece0decc41229fed6d9e2L28-R30) [[3]](diffhunk://#diff-0dec717b0e3ae68dc987282d3743000959980f0938ee07042cc84ce45206bfadL16-R16)

**CI/CD Pipeline Adjustments:**

* The Azure Pipelines configuration is updated to use a parameterized SDK version (`8.x`) instead of relying on `global.json`, ensuring the build pipeline uses .NET 8 throughout all stages. [[1]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5R44-R45) [[2]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L58-R60) [[3]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L125-R127) [[4]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L201-R203)

**Test Project Clean-up:**

* Removes unused or outdated package references from test project files, such as `System.IdentityModel.Tokens.Jwt` in `FileShareService.DesktopClient.CoreTests`.

These changes ensure the solution is up-to-date with the latest .NET platform and dependencies, improving support, security, and compatibility with modern tooling.